### PR TITLE
Support for Shoutem Platform v2

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  tabWidth: 2
+};

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
 
     implementation "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:6.0.0-shoutem'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:6.0.0-shoutem'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:6.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:6.1.0'
 
-    implementation 'co.nearbee:nearbeesdk:0.1.6'
+    implementation 'co.nearbee:nearbeesdk:0.2.1'
 }

--- a/app/android/src/main/java/com/kumulos/android/shoutem/KumulosShoutemModule.java
+++ b/app/android/src/main/java/com/kumulos/android/shoutem/KumulosShoutemModule.java
@@ -18,10 +18,10 @@ import com.kumulos.android.Kumulos;
 
 import java.util.ArrayList;
 
+import co.nearbee.NearBeaconListener;
 import co.nearbee.NearBee;
-import co.nearbee.NearBeeBeacon;
 import co.nearbee.NearBeeException;
-import co.nearbee.NearBeeListener;
+import co.nearbee.models.NearBeacon;
 
 public class KumulosShoutemModule extends ReactContextBaseJavaModule {
 
@@ -74,20 +74,20 @@ public class KumulosShoutemModule extends ReactContextBaseJavaModule {
                 .setBackgroundNotificationsEnabled(true);
         NearBee nearBee = builder.build();
 
-        nearBee.startScanning(new NearBeeListener() {
+        nearBee.startScanning(new NearBeaconListener() {
             @Override
-            public void onUpdate(ArrayList<NearBeeBeacon> beaconsInRange) {
+            public void onUpdate(ArrayList<NearBeacon> beaconsInRange) {
                 // Noop
             }
 
             @Override
-            public void onBeaconLost(ArrayList<NearBeeBeacon> lostBeacons) {
+            public void onBeaconLost(ArrayList<NearBeacon> lostBeacons) {
                 // Noop
             }
 
             @Override
-            public void onBeaconFound(ArrayList<NearBeeBeacon> foundBeacons) {
-                for (NearBeeBeacon beacon : foundBeacons) {
+            public void onBeaconFound(ArrayList<NearBeacon> foundBeacons) {
+                for (NearBeacon beacon : foundBeacons) {
                     String uid = beacon.getEddystoneUID();
                     String hexNamespace = uid.substring(0, 20);
                     String hexInstance = uid.substring(20);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kumulos.kumulos",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,9 +28,9 @@
       "integrity": "sha1-ONo0cYF9+dRKs4kuJ3B7u9daEbk="
     },
     "kumulos-react-native": {
-      "version": "2.1.0-shoutem",
-      "resolved": "https://registry.npmjs.org/kumulos-react-native/-/kumulos-react-native-2.1.0-shoutem.tgz",
-      "integrity": "sha512-mhEFoSGPL0SkuxlQ6Aw2uPHswZRg7TrWvzKbfSoo8mApv8q3FDCQf5sLEcRnmZPISFXHDkpt0cnL31uVdQl3iw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kumulos-react-native/-/kumulos-react-native-3.0.0.tgz",
+      "integrity": "sha512-UVLUpCqrPC9pmuw/m8YjpiRR1vKzzKHnN45txo+g+zRpmGzimkwEyF1cuwEzoduxigpWxP75Y9WfPehtAfNIdA==",
       "requires": {
         "base-64": "^0.1.0",
         "raven-js": "^3.26.3"
@@ -63,9 +63,9 @@
       }
     },
     "raven-js": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.0.tgz",
-      "integrity": "sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw=="
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
+      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ=="
     },
     "simple-plist": {
       "version": "0.1.4",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.7",
   "description": "Testing",
   "dependencies": {
-    "kumulos-react-native": "2.1.0-shoutem",
+    "kumulos-react-native": "3.0.0",
     "xcode": "^0.8.9",
     "plist": "1.2.0",
     "lodash": "~4.17.4"

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -99,7 +99,7 @@ const iOSPushDelegateCode = `
     NSString *url = userInfo[@"custom"][@"u"];
     if (url) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        [self.nearBee displayContentOfEddystoneUrl:url];
+        [UIApplication.sharedApplication openURL:[NSURL URLWithString:url]];
       });
     }
 #endif
@@ -125,7 +125,15 @@ const iOSPushDelegateCode = `
   // Handle URL pushes
   NSString *url = userInfo[@"custom"][@"u"];
   if (url) {
-    [self.nearBee displayContentOfEddystoneUrl:url];
+    if (@available(iOS 10.0, *)) {
+      [UIApplication.sharedApplication openURL:[NSURL URLWithString:url] options:@{} completionHandler:^(BOOL success) {
+        /* noop */
+      }];
+    } else {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [UIApplication.sharedApplication openURL:[NSURL URLWithString:url]];
+      });
+    }
   }
 
   completionHandler();

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -135,7 +135,14 @@ const iOSPushDelegateCode = `
 module.exports = {
   ios: {
     podDeps: `
-  pod 'NearBee', '0.1.0'
+    pod 'NearBee', '0.1.0'
+`,
+    podTargets: `
+    if target.name == 'Starscream'
+        target.build_configurations.each do |config|
+            config.build_settings['SWIFT_VERSION'] = '4.2'
+        end
+    end
 `,
     delegateBody: `
 ${iOSLocationDelegateCode}

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -47,7 +47,7 @@ const iOSLocationDelegateCode = `
 
 #pragma mark - NearBee delegates
 
-- (void)onBeaconsFound:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
+- (void)didFindBeacons:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
   for (NearBeeBeacon *beacon in beacons) {
     if (!beacon.eddystoneUID) {
       continue;
@@ -64,16 +64,20 @@ const iOSLocationDelegateCode = `
   }
 }
 
-- (void)onBeaconsLost:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
+- (void)didLoseBeacons:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
   // Noop
 }
 
-- (void)onBeaconsUpdated:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
-  // Noop
-}
-
-- (void)onError:(NSError * _Nonnull)error {
+- (void)didThrowError:(NSError * _Nonnull)error {
   NSLog(@"NearBee error: %@", error);
+}
+
+- (void)didUpdateBeacons:(NSArray<NearBeeBeacon *> * _Nonnull)beacons {
+  // Noop
+}
+
+- (void)didUpdateState:(enum NearBeeState)state {
+  // Noop
 }
 `;
 

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -114,7 +114,7 @@ const iOSPushDelegateCode = `
 
 // Called on iOS10 when your app is in the foreground to allow customizing the display of the notification
 - (void) userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-  completionHandler(UNNotificationPresentationOptionNone);
+  completionHandler(UNNotificationPresentationOptionAlert);
 }
 
 // iOS10 handler for when a user taps a notification

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -135,14 +135,7 @@ const iOSPushDelegateCode = `
 module.exports = {
   ios: {
     podDeps: `
-    pod 'NearBee', '0.1.0'
-`,
-    podTargets: `
-    if target.name == 'Starscream'
-        target.build_configurations.each do |config|
-            config.build_settings['SWIFT_VERSION'] = '4.2'
-        end
-    end
+    pod 'NearBee', '0.2.0'
 `,
     delegateBody: `
 ${iOSLocationDelegateCode}

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -147,7 +147,7 @@ const iOSPushDelegateCode = `
 module.exports = {
   ios: {
     podDeps: `
-    pod 'NearBee', '0.2.1'
+    pod 'NearBee', '0.2.3'
 `,
     delegateBody: `
 ${iOSLocationDelegateCode}

--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -147,7 +147,7 @@ const iOSPushDelegateCode = `
 module.exports = {
   ios: {
     podDeps: `
-    pod 'NearBee', '0.2.0'
+    pod 'NearBee', '0.2.1'
 `,
     delegateBody: `
 ${iOSLocationDelegateCode}

--- a/app/scripts/inject.js
+++ b/app/scripts/inject.js
@@ -50,11 +50,18 @@ function injectIos() {
     consts.ios.podDeps
   );
 
+  inject(
+    podfilePath,
+    ANCHORS.IOS.PODFILE.EXTENSION_POSTINSTALL_TARGETS,
+    consts.ios.podTargets
+  );
+
   replace(
     appDelegatePath,
     consts.ios.findDelegateLine,
     consts.ios.replaceDelegateLine
   );
+
   replace(
     appDelegatePath,
     consts.ios.findDidLaunch,

--- a/app/scripts/inject.js
+++ b/app/scripts/inject.js
@@ -50,12 +50,6 @@ function injectIos() {
     consts.ios.podDeps
   );
 
-  inject(
-    podfilePath,
-    ANCHORS.IOS.PODFILE.EXTENSION_POSTINSTALL_TARGETS,
-    consts.ios.podTargets
-  );
-
   replace(
     appDelegatePath,
     consts.ios.findDelegateLine,

--- a/app/scripts/inject.js
+++ b/app/scripts/inject.js
@@ -118,8 +118,8 @@ function injectAndroid() {
     ANCHORS.ANDROID.GRADLE.APP.DEPENDENCIES,
     `
     // Kumulos SDK start
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:6.0.0-shoutem'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:6.0.0-shoutem'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:6.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:6.1.0'
 
     implementation 'co.nearbee:nearbeesdk:0.1.6'
     // Kumulos SDK end

--- a/app/scripts/inject.js
+++ b/app/scripts/inject.js
@@ -196,7 +196,7 @@ function injectNearBeeRepo(gradlePath) {
     }
   }
 
-  if (insertIdx === lines.length - 1) {
+  if (insertIdx === lines.length) {
     return;
   }
 

--- a/app/scripts/postlink.js
+++ b/app/scripts/postlink.js
@@ -4,6 +4,7 @@ const {
 } = require("@shoutem/build-tools");
 
 const xcode = require("xcode");
+const fs = require('fs');
 
 const { injectKumulos } = require("./inject");
 
@@ -13,6 +14,7 @@ const xcodeprojPath = getXcodeProjectPath();
 const xcodeProject = xcode.project(xcodeprojPath).parseSync();
 
 // Set up SWIFT_VERSION to allow depending on SocketIO client pod
-xcodeProject.addToBuildSettings("SWIFT_VERSION", "4");
+xcodeProject.addToBuildSettings('SWIFT_VERSION', '4.2');
+fs.writeFileSync(xcodeprojPath, xcodeProject.writeSync());
 
 injectKumulos();

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kumulos",
-  "version": "0.0.23",
+  "version": "0.0.28",
   "title": "Kumulos",
   "icon": "server/assets/kumulos-extension-cover.png",
   "description": "Kumulos provides audience and engagement analytics, marketing automation and geo-targeted notifications for your app.",


### PR DESCRIPTION
Updates to support Shoutem Platform v2:

- Update to Kumulos RN SDK v3 (supporting RN 0.59)
- Bump native iOS & Android SDK dependencies to matching versions
- Update NearBee SDK versions & usage to support RN 0.59 / Platform v2
- Inject NearBee private maven repo for Android
- Always show a notification alert on iOS when a push is received whilst the app is foregrounded (more consistent with other SDKs and what users expect)

~~Note iOS simulator builds do not currently work so testing must be performed against a physical device.~~