### PR TITLE
Inject native iOS configuration for initialization

### DIFF
--- a/app/scripts/consts.js
+++ b/app/scripts/consts.js
@@ -165,13 +165,6 @@ ${iOSPushDelegateCode}
 @implementation AppDelegate
 `,
     findDidLaunch: `return YES;`,
-    replaceDidLaunch: `
-  [self setupLocationMonitoring:launchOptions];
-  [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
-  [Kumulos.shared pushRequestDeviceToken];
-
-  return YES;
-`,
     delegateImports: `
 @import CoreLocation;
 @import UserNotifications;

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kumulos",
-  "version": "0.0.28",
+  "version": "0.0.31",
   "title": "Kumulos",
   "icon": "server/assets/kumulos-extension-cover.png",
   "description": "Kumulos provides audience and engagement analytics, marketing automation and geo-targeted notifications for your app.",


### PR DESCRIPTION
Fixes race condition with push registration where JS init delegating to native
could take longer than appDidLaunch requesting the push token.